### PR TITLE
Bump Gazebo to v11.11.0

### DIFF
--- a/gazebo/.SRCINFO
+++ b/gazebo/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = gazebo
 	pkgdesc = A multi-robot simulator for outdoor environments
-	pkgver = 11.10.2
-	pkgrel = 3
+	pkgver = 11.11.0
+	pkgrel = 1
 	url = http://gazebosim.org/
 	install = gazebo.install
 	arch = i686
@@ -40,9 +40,7 @@ pkgbase = gazebo
 	optdepends = libusb: USB peripherals support
 	optdepends = simbody: Simbody support
 	optdepends = urdfdom: Load URDF files
-	source = gazebo-11.10.2.tar.gz::https://github.com/osrf/gazebo/archive/gazebo11_11.10.2.tar.gz
-	source = string.patch::https://github.com/osrf/gazebo/commit/2f0f7af4868883d1a6fea30086b3fcd703d583fc.patch
-	sha256sums = 9570454e0341e40881ed8659f8ec9aa45e24d172421e8556d0714cf7b5018511
-	sha256sums = a94a7e22696074f88ae1a8f2af3f39ef5041b91785b2b52a73dbf8b9a1c4fd52
+	source = gazebo-11.11.0.tar.gz::https://github.com/osrf/gazebo/archive/gazebo11_11.11.0.tar.gz
+	sha256sums = e6a1965198378a8360ab7fce465990f11951629a833e518c2163c645d015354a
 
 pkgname = gazebo

--- a/gazebo/PKGBUILD
+++ b/gazebo/PKGBUILD
@@ -8,8 +8,8 @@
 # Contributor: Vladimir Ermakov <vooon341@gmail.com>
 
 pkgname=gazebo
-pkgver=11.10.2
-pkgrel=3
+pkgver=11.11.0
+pkgrel=1
 pkgdesc="A multi-robot simulator for outdoor environments"
 arch=('i686' 'x86_64')
 url="http://gazebosim.org/"
@@ -28,15 +28,12 @@ optdepends=('bullet: Bullet support'
             'urdfdom: Load URDF files')
 makedepends=('cmake' 'doxygen' 'ruby-ronn')
 install="${pkgname}.install"
-source=("${pkgname}-${pkgver}.tar.gz::https://github.com/osrf/gazebo/archive/${pkgname}11_$pkgver.tar.gz"
-        "string.patch"::"https://github.com/osrf/gazebo/commit/2f0f7af4868883d1a6fea30086b3fcd703d583fc.patch")
-sha256sums=('9570454e0341e40881ed8659f8ec9aa45e24d172421e8556d0714cf7b5018511'
-            'a94a7e22696074f88ae1a8f2af3f39ef5041b91785b2b52a73dbf8b9a1c4fd52')
+source=("${pkgname}-${pkgver}.tar.gz::https://github.com/osrf/gazebo/archive/${pkgname}11_$pkgver.tar.gz")
+sha256sums=('e6a1965198378a8360ab7fce465990f11951629a833e518c2163c645d015354a')
 
 prepare() {
   cd "${srcdir}/${pkgname}-${pkgname}11_$pkgver"
 
-  patch --strip=1 < "${srcdir}/string.patch"
   sed -i 's/putstr/printf/g' gazebo/gui/qgv/private/QGVCore.h
 }
 

--- a/gazebo/PKGBUILD
+++ b/gazebo/PKGBUILD
@@ -37,6 +37,7 @@ prepare() {
   cd "${srcdir}/${pkgname}-${pkgname}11_$pkgver"
 
   patch --strip=1 < "${srcdir}/string.patch"
+  sed -i 's/putstr/printf/g' gazebo/gui/qgv/private/QGVCore.h
 }
 
 build() {


### PR DESCRIPTION
Closes #33.
Patches #32 

Bumps Gazebo to the latest version. The other patch is no longer needed.
