### PR TITLE
upgpkg: gazebo 11.12.0-2

### DIFF
--- a/gazebo/.SRCINFO
+++ b/gazebo/.SRCINFO
@@ -1,8 +1,8 @@
 pkgbase = gazebo
 	pkgdesc = A multi-robot simulator for outdoor environments
 	pkgver = 11.12.0
-	pkgrel = 1
-	url = http://gazebosim.org/
+	pkgrel = 2
+	url = https://classic.gazebosim.org/
 	install = gazebo.install
 	arch = i686
 	arch = x86_64
@@ -40,7 +40,7 @@ pkgbase = gazebo
 	optdepends = libusb: USB peripherals support
 	optdepends = simbody: Simbody support
 	optdepends = urdfdom: Load URDF files
-	source = gazebo-11.12.0.tar.gz::https://github.com/osrf/gazebo/archive/gazebo11_11.12.0.tar.gz
-	sha256sums = 6ef2721c1279bc836a845022784fb8bf9860468b36abbc5c1887446ea594d261
+	source = gazebo-11.12.0.tar.gz::https://github.com/gazebosim/gazebo-classic/archive/gazebo11_11.12.0.tar.gz
+	sha256sums = c4d32b76c213b0f74f01a10d2134232280a13fb58529f9a2ce8a7ab7bca8691a
 
 pkgname = gazebo

--- a/gazebo/PKGBUILD
+++ b/gazebo/PKGBUILD
@@ -9,10 +9,10 @@
 
 pkgname=gazebo
 pkgver=11.12.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A multi-robot simulator for outdoor environments"
 arch=('i686' 'x86_64')
-url="http://gazebosim.org/"
+url="https://classic.gazebosim.org/"
 license=('Apache')
 depends=('boost' 'curl' 'freeglut' 'freeimage' 'tbb' 'libccd' 'libltdl' 'graphviz'
          'libtar' 'libxml2' 'ogre-1.9' 'protobuf>=2.3.0' 'sdformat-9' 'ignition-math>=6' 'ignition-transport-8'
@@ -28,11 +28,13 @@ optdepends=('bullet: Bullet support'
             'urdfdom: Load URDF files')
 makedepends=('cmake' 'doxygen' 'ruby-ronn')
 install="${pkgname}.install"
-source=("${pkgname}-${pkgver}.tar.gz::https://github.com/osrf/gazebo/archive/${pkgname}11_$pkgver.tar.gz")
-sha256sums=('6ef2721c1279bc836a845022784fb8bf9860468b36abbc5c1887446ea594d261')
+source=("${pkgname}-${pkgver}.tar.gz::https://github.com/gazebosim/gazebo-classic/archive/${pkgname}11_$pkgver.tar.gz")
+sha256sums=('c4d32b76c213b0f74f01a10d2134232280a13fb58529f9a2ce8a7ab7bca8691a')
+
+_pkgname=gazebo-classic
 
 build() {
-  cd "${srcdir}/${pkgname}-${pkgname}11_$pkgver"
+  cd "${srcdir}/${_pkgname}-${pkgname}11_$pkgver"
 
   mkdir -p build && cd build
 
@@ -44,6 +46,6 @@ build() {
 }
 
 package() {
-  cd "${srcdir}/${pkgname}-${pkgname}11_$pkgver/build"
+  cd "${srcdir}/${_pkgname}-${pkgname}11_$pkgver/build"
   DESTDIR="${pkgdir}" make install
 }


### PR DESCRIPTION
upgpkg: gazebo 11.2.0-2

source url updated

checksum started to fail for me, figured out the gazebo repo has changed to https://github.com/gazebosim/gazebo-classic