### PR TITLE
ogre-next support

### DIFF
--- a/ignition-cmake/.SRCINFO
+++ b/ignition-cmake/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ignition-cmake
 	pkgdesc = A set of CMake modules that are used by the C++-based Gazebo projects.
 	pkgver = 3.0.1
-	pkgrel = 1
+	pkgrel = 2
 	url = https://gazebosim.org/libs/cmake
 	arch = any
 	license = Apache
@@ -10,6 +10,8 @@ pkgbase = ignition-cmake
 	depends = ruby-ronn
 	depends = doxygen
 	source = https://github.com/gazebosim/gz-cmake/archive/gz-cmake3_3.0.1.tar.gz
+	source = find-ogre.patch
 	sha256sums = d211e1a5384b33968a0b755dd6bded512f3e2957d2f04766ec17b0b5114201a0
+	sha256sums = 3d9c2847be37fa5ad63fb4edf177cc36eefd6481741fd1ea28b505be304cc9de
 
 pkgname = ignition-cmake

--- a/ignition-cmake/PKGBUILD
+++ b/ignition-cmake/PKGBUILD
@@ -3,17 +3,22 @@
 
 pkgname=ignition-cmake
 pkgver=3.0.1
-pkgrel=1
+pkgrel=2
 pkgdesc="A set of CMake modules that are used by the C++-based Gazebo projects."
 arch=('any')
 url="https://gazebosim.org/libs/cmake"
 license=('Apache')
 depends=('cmake' 'pkg-config' 'ruby-ronn' 'doxygen')
-source=("https://github.com/gazebosim/gz-cmake/archive/gz-cmake3_${pkgver}.tar.gz")
-sha256sums=('d211e1a5384b33968a0b755dd6bded512f3e2957d2f04766ec17b0b5114201a0')
+source=("https://github.com/gazebosim/gz-cmake/archive/gz-cmake3_${pkgver}.tar.gz"
+		find-ogre.patch)
+sha256sums=('d211e1a5384b33968a0b755dd6bded512f3e2957d2f04766ec17b0b5114201a0'
+            '3d9c2847be37fa5ad63fb4edf177cc36eefd6481741fd1ea28b505be304cc9de')
 
 _dir="gz-cmake-gz-cmake3_${pkgver}"
 
+prepare() {
+	patch $_dir/cmake/FindGzOGRE2.cmake -i find-ogre.patch
+}
 build() {
   cd "$srcdir/$_dir"
 

--- a/ignition-cmake/find-ogre.patch
+++ b/ignition-cmake/find-ogre.patch
@@ -1,0 +1,13 @@
+152c152
+<   foreach (GZ_OGRE2_PROJECT_NAME "OGRE2" "OGRE-Next")
+---
+>   foreach (GZ_OGRE2_PROJECT_NAME "OGRE2" "OGRE-Next" "OGRE")
+164c164
+<     else()
+---
+>     elseif (GZ_OGRE2_PROJECT_NAME STREQUAL "OGRE-Next")
+167a168,171
+>     else()
+>       # Match ArchLinux
+>       set(OGRE2_INSTALL_PATH "OGRE")
+>       set(OGRE2LIBNAME "Ogre")

--- a/ignition-rendering/.SRCINFO
+++ b/ignition-rendering/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ignition-rendering
 	pkgdesc = C++ library designed to provide an abstraction for different rendering engines. It offers unified APIs for creating 3D graphics applications.
 	pkgver = 7.2.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://gazebosim.org/libs/rendering
 	arch = x86_64
 	license = Apache
@@ -10,7 +10,8 @@ pkgbase = ignition-rendering
 	depends = ignition-common
 	depends = ignition-math
 	depends = ignition-plugin
-	depends = ogre=1.9
+	depends = ogre-next
+	depends = eigen
 	source = ignition-rendering-7.2.0.tar.gz::https://github.com/gazebosim/gz-rendering/archive/gz-rendering7_7.2.0.tar.gz
 	sha256sums = adc48405f326a2f6762a278a0ff7f5b3d379a761d64df4642e26f821912b0f92
 

--- a/ignition-rendering/PKGBUILD
+++ b/ignition-rendering/PKGBUILD
@@ -2,13 +2,13 @@
 
 pkgname=ignition-rendering
 pkgver=7.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc="C++ library designed to provide an abstraction for different rendering
 engines. It offers unified APIs for creating 3D graphics applications."
 arch=('x86_64')
 url="https://gazebosim.org/libs/rendering"
 license=('Apache')
-depends=('ignition-common' 'ignition-math' 'ignition-plugin' 'ogre=1.9')
+depends=('ignition-common' 'ignition-math' 'ignition-plugin' 'ogre-next' 'eigen')
 makedepends=('cmake' 'ignition-cmake')
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/gazebosim/gz-rendering/archive/gz-rendering7_${pkgver}.tar.gz")
 sha256sums=('adc48405f326a2f6762a278a0ff7f5b3d379a761d64df4642e26f821912b0f92')


### PR DESCRIPTION
gz-rendering also supports ogre-next. Currently gz-cmake cannot find ogre-next on Archlinux.

I could run Gazebo but not thoroughly test gazebo with ogre-next, so I did not post the patch upstream.