### PR TITLE
Ignition common 3 add patch for ffmpeg6

### DIFF
--- a/ignition-common-3/.SRCINFO
+++ b/ignition-common-3/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ignition-common-3
 	pkgdesc = Provides a set of libraries that cover many different use cases.
 	pkgver = 3.15.1
-	pkgrel = 1
+	pkgrel = 2
 	url = https://gazebosim.org/libs/common
 	arch = x86_64
 	groups = development
@@ -17,7 +17,9 @@ pkgbase = ignition-common-3
 	provides = ignition-common=3
 	source = ignition-common-3-3.15.1.tar.gz::https://github.com/gazebosim/gz-common/archive/ignition-common3_3.15.1.tar.gz
 	source = missing-include-cstring.patch::https://github.com/gazebosim/gz-common/commit/465bb7780e552b278de559fafaffe3d061a99782.patch
+	source = ./ffmpeg6.patch
 	sha256sums = fc1bf79eb53e3b56b4b8e0eb6965ec68982da18ea42154dd4fd891ac739d65fb
 	sha256sums = 9a6f2d45a1c2146150336e25162f6ba46f19db1deb46b2b644a8faa3afe3d7af
+	sha256sums = bb8e5a620605b34815cfc649a96462e63fc301a88e15fb447bcc31f59a0d9a5e
 
 pkgname = ignition-common-3

--- a/ignition-common-3/PKGBUILD
+++ b/ignition-common-3/PKGBUILD
@@ -1,9 +1,10 @@
 # Maintainer: acxz <akashpatel2008 at yahoo dot com>
 # Maintainer: Homalozoa <nx.tardis@gmail.com>
+# Contributor: Bernd Müller <github@muellerbernd.de>
 
 pkgname=ignition-common-3
 pkgver=3.15.1
-pkgrel=1
+pkgrel=2
 pkgdesc="Provides a set of libraries that cover many different use cases."
 arch=('x86_64')
 url="https://gazebosim.org/libs/common"
@@ -13,15 +14,18 @@ depends=('ignition-math=6' 'tinyxml2' 'freeimage' 'libutil-linux' 'gts' 'ffmpeg'
 makedepends=('ignition-cmake=2' 'util-linux')
 provides=("ignition-common=3")
 source=("${pkgname}-${pkgver}.tar.gz::https://github.com/gazebosim/gz-common/archive/ignition-common3_${pkgver}.tar.gz"
-        "missing-include-cstring.patch::https://github.com/gazebosim/gz-common/commit/465bb7780e552b278de559fafaffe3d061a99782.patch")
+        "missing-include-cstring.patch::https://github.com/gazebosim/gz-common/commit/465bb7780e552b278de559fafaffe3d061a99782.patch"
+        "./ffmpeg6.patch")
 sha256sums=('fc1bf79eb53e3b56b4b8e0eb6965ec68982da18ea42154dd4fd891ac739d65fb'
-            '9a6f2d45a1c2146150336e25162f6ba46f19db1deb46b2b644a8faa3afe3d7af')
+            '9a6f2d45a1c2146150336e25162f6ba46f19db1deb46b2b644a8faa3afe3d7af'
+            'bb8e5a620605b34815cfc649a96462e63fc301a88e15fb447bcc31f59a0d9a5e')
 
 _dir="gz-common-ignition-common3_${pkgver}"
 
 prepare() {
   cd "$srcdir/$_dir"
   patch -p1 < ../missing-include-cstring.patch
+  patch -Np1 -i ${srcdir}/ffmpeg6.patch
 }
 
 build() {

--- a/ignition-common-3/ffmpeg6.patch
+++ b/ignition-common-3/ffmpeg6.patch
@@ -1,0 +1,41 @@
+diff --color -Naur gz-common-ignition-common3_3.15.1/av/src/AudioDecoder.cc gz-common-ignition-common3_3.15.1_new/av/src/AudioDecoder.cc
+--- A/av/src/AudioDecoder.cc    2022-10-11 23:26:53.000000000 +0200
++++ B/av/src/AudioDecoder.cc    2023-03-10 08:25:26.284516672 +0100
+@@ -344,12 +344,9 @@
+     return false;
+   }
+
+-#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(56, 60, 100)
+-  if (this->data->codec->capabilities & AV_CODEC_CAP_TRUNCATED)
+-    this->data->codecCtx->flags |= AV_CODEC_FLAG_TRUNCATED;
+-#else
+-  if (this->data->codec->capabilities & CODEC_CAP_TRUNCATED)
+-    this->data->codecCtx->flags |= CODEC_FLAG_TRUNCATED;
++#if LIBAVCODEC_VERSION_MAJOR < 60
++    if (d->codec->capabilities & CODEC_CAP_TRUNC)
++        d->decoder->flags |= CODEC_FLAG_TRUNC;
+ #endif
+
+   // Open codec
+diff --color -Naur gz-common-ignition-common3_3.15.1/av/src/Video.cc gz-common-ignition-common3_3.15.1_new/av/src/Video.cc
+--- A/av/src/Video.cc   2022-10-11 23:26:53.000000000 +0200
++++ B/av/src/Video.cc   2023-03-10 08:26:11.068487128 +0100
+@@ -181,12 +181,9 @@
+
+   // Inform the codec that we can handle truncated bitstreams -- i.e.,
+   // bitstreams where frame boundaries can fall in the middle of packets
+-#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(56, 60, 100)
+-  if (codec->capabilities & AV_CODEC_CAP_TRUNCATED)
+-    this->dataPtr->codecCtx->flags |= AV_CODEC_FLAG_TRUNCATED;
+-#else
+-  if (codec->capabilities & CODEC_CAP_TRUNCATED)
+-    this->dataPtr->codecCtx->flags |= CODEC_FLAG_TRUNCATED;
++#if LIBAVCODEC_VERSION_MAJOR < 60
++    if (d->codec->capabilities & CODEC_CAP_TRUNC)
++        d->decoder->flags |= CODEC_FLAG_TRUNC;
+ #endif
+
+   // Open codec
+diff --color -Naur gz-common-ignition-common3_3.15.1/build/av/src/CMakeFiles/ignition-common3-av.dir/AudioDecoder.cc.o gz-common-ignition-common3_3.15.1_new/build/av/src/CMakeFiles/ignition-common3-av.dir/AudioDecoder.cc.o
+--- gz-common-ignition-common3_3.15.1/build/av/src/CMakeFiles/ignition-common3-av.dir/AudioDecoder.cc.o 1970-01-01 01:00:00.000000000 +0100
++++ gz-common-ignition-common3_3.15.1_new/build/av/src/CMakeFiles/ignition-common3-av.dir/AudioDecoder.cc.o 2023-03-10 08:22:05.205049145 +0100


### PR DESCRIPTION
I had problems with ignition-common-3 since the last update of ffmpeg to version so I made a patch. Now ignition-common-3 builds fine. The patch was inspired from https://github.com/obsproject/obs-studio/pull/8376.

Solves #56 