### PR TITLE
[gazebo] add patch for graphviz 9

### DIFF
--- a/gazebo/.SRCINFO
+++ b/gazebo/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = gazebo
 	pkgdesc = A multi-robot simulator for outdoor environments
 	pkgver = 11.13.0
-	pkgrel = 2
+	pkgrel = 3
 	url = https://classic.gazebosim.org/
 	install = gazebo.install
 	arch = i686
@@ -42,6 +42,8 @@ pkgbase = gazebo
 	optdepends = simbody: Simbody support
 	optdepends = urdfdom: Load URDF files
 	source = gazebo-11.13.0.tar.gz::https://github.com/gazebosim/gazebo-classic/archive/gazebo11_11.13.0.tar.gz
+	source = graphviz9.patch::https://github.com/gazebosim/gazebo-classic/commit/87ac01bd72c7b35217ab9ebf69cba69dc7780b39.patch
 	sha256sums = a990f27dd08e4461107ef8e29eef18470789e7cd87cdb26e7f384769603537fd
+	sha256sums = 8dc4c72dd1e1107c5b026950c6c284b3cac988076505067442b0141eb3488cdf
 
 pkgname = gazebo

--- a/gazebo/PKGBUILD
+++ b/gazebo/PKGBUILD
@@ -10,7 +10,7 @@
 
 pkgname=gazebo
 pkgver=11.13.0
-pkgrel=2
+pkgrel=3
 pkgdesc="A multi-robot simulator for outdoor environments"
 arch=('i686' 'x86_64')
 url="https://classic.gazebosim.org/"
@@ -29,10 +29,17 @@ optdepends=('bullet: Bullet support'
             'urdfdom: Load URDF files')
 makedepends=('cmake' 'doxygen' 'ruby-ronn')
 install="${pkgname}.install"
-source=("${pkgname}-${pkgver}.tar.gz::https://github.com/gazebosim/gazebo-classic/archive/${pkgname}11_$pkgver.tar.gz")
-sha256sums=('a990f27dd08e4461107ef8e29eef18470789e7cd87cdb26e7f384769603537fd')
+source=("${pkgname}-${pkgver}.tar.gz::https://github.com/gazebosim/gazebo-classic/archive/${pkgname}11_$pkgver.tar.gz"
+    "graphviz9.patch"::"https://github.com/gazebosim/gazebo-classic/commit/87ac01bd72c7b35217ab9ebf69cba69dc7780b39.patch")
+sha256sums=('a990f27dd08e4461107ef8e29eef18470789e7cd87cdb26e7f384769603537fd'
+            '8dc4c72dd1e1107c5b026950c6c284b3cac988076505067442b0141eb3488cdf')
 
 _pkgname=gazebo-classic
+
+prepare() {
+  cd "${srcdir}/${_pkgname}-${pkgname}11_$pkgver"
+  patch -Np1 -i ${srcdir}/graphviz9.patch
+}
 
 build() {
   cd "${srcdir}/${_pkgname}-${pkgname}11_$pkgver"
@@ -51,3 +58,4 @@ package() {
   cd "${srcdir}/${_pkgname}-${pkgname}11_$pkgver/build"
   DESTDIR="${pkgdir}" make install
 }
+# vim:ts=2:sw=2:et:

--- a/gazebo/PKGBUILD
+++ b/gazebo/PKGBUILD
@@ -10,14 +10,14 @@
 
 pkgname=gazebo
 pkgver=11.13.0
-pkgrel=3
+pkgrel=4
 pkgdesc="A multi-robot simulator for outdoor environments"
 arch=('i686' 'x86_64')
 url="https://classic.gazebosim.org/"
 license=('Apache')
 depends=('boost' 'curl' 'freeglut' 'freeimage' 'tbb' 'libccd' 'libltdl' 'graphviz'
          'libtar' 'libxml2' 'ogre-1.9' 'protobuf' 'sdformat-9' 'ignition-math-6' 'ignition-transport-8'
-         'ignition-cmake-2' 'ignition-common-3' 'ignition-fuel_tools-4' 'ignition-msgs-5' 'tinyxml2' 'qwt' 'cppzmq')
+         'ignition-cmake-2' 'ignition-common-3' 'ignition-fuel_tools-4' 'ignition-msgs-5' 'tinyxml2' 'qwt' 'cppzmq' 'libdart')
 optdepends=('bullet: Bullet support'
             'cegui: Design custom graphical interfaces'
             'ffmpeg4.4: Playback movies on textured surfaces'


### PR DESCRIPTION
Adds patch for graphviz 9 like in the [upstream repo](https://github.com/gazebosim/gazebo-classic/commit/87ac01bd72c7b35217ab9ebf69cba69dc7780b39)