### PR TITLE
Add cppzmq to ignition-transport depends array.

### DIFF
--- a/ignition-transport/.SRCINFO
+++ b/ignition-transport/.SRCINFO
@@ -17,6 +17,7 @@ pkgbase = ignition-transport
 	depends = ignition-utils>1
 	depends = libutil-linux
 	depends = tinyxml2
+	depends = cppzmq
 	source = ignition-transport-13.0.0.tar.gz::https://github.com/gazebosim/gz-transport/archive/gz-transport13_13.0.0.tar.gz
 	sha256sums = 8041d81693b69a94e36477178fdf1964f32725e520c33fec2e69c60f28fd84ca
 

--- a/ignition-transport/PKGBUILD
+++ b/ignition-transport/PKGBUILD
@@ -11,7 +11,7 @@ url="https://gazebosim.org/libs/transport"
 license=('Apache')
 groups=('development')
 depends=('protobuf' 'protobuf-c' 'zeromq' 'ignition-msgs>5' 'ignition-tools>1'
-         'ignition-utils>1' 'libutil-linux' 'tinyxml2')
+         'ignition-utils>1' 'libutil-linux' 'tinyxml2' 'cppzmq')
 makedepends=('ignition-cmake>2' 'util-linux')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/gazebosim/gz-transport/archive/gz-transport13_${pkgver}.tar.gz")
 sha256sums=('8041d81693b69a94e36477178fdf1964f32725e520c33fec2e69c60f28fd84ca')


### PR DESCRIPTION
Fixes issue #93 
Build and package logs included.
[ignition-transport-13.0.0-1-x86_64-build.log](https://github.com/acxz/gazebo-arch/files/14489068/ignition-transport-13.0.0-1-x86_64-build.log)
[ignition-transport-13.0.0-1-x86_64-package.log](https://github.com/acxz/gazebo-arch/files/14489069/ignition-transport-13.0.0-1-x86_64-package.log)
