### PR TITLE
Update gazebo PKGBUILD to include gazebosim/gazebo-classic#3373 , to …

### DIFF
--- a/gazebo/.SRCINFO
+++ b/gazebo/.SRCINFO
@@ -42,6 +42,8 @@ pkgbase = gazebo
 	optdepends = simbody: Simbody support
 	optdepends = urdfdom: Load URDF files
 	source = gazebo-11.14.0.tar.gz::https://github.com/gazebosim/gazebo-classic/archive/gazebo11_11.14.0.tar.gz
+	source = graphviz-10.patch::https://github.com/gazebosim/gazebo-classic/pull/3373.patch
 	sha256sums = 6b63d857399ba08190c331b545d24e8e3e308b840ff051bbf39e87879e37af50
+	sha256sums = 60e40900a03308f52dfdb160e36066b53b9af8b5ee1174810d21148bc44ff31f
 
 pkgname = gazebo

--- a/gazebo/PKGBUILD
+++ b/gazebo/PKGBUILD
@@ -29,10 +29,17 @@ optdepends=('bullet: Bullet support'
             'urdfdom: Load URDF files')
 makedepends=('cmake' 'doxygen' 'ruby-ronn')
 install="${pkgname}.install"
-source=("${pkgname}-${pkgver}.tar.gz::https://github.com/gazebosim/gazebo-classic/archive/${pkgname}11_$pkgver.tar.gz")
-sha256sums=('6b63d857399ba08190c331b545d24e8e3e308b840ff051bbf39e87879e37af50')
+source=("${pkgname}-${pkgver}.tar.gz::https://github.com/gazebosim/gazebo-classic/archive/${pkgname}11_$pkgver.tar.gz"
+        "graphviz-10.patch::https://github.com/gazebosim/gazebo-classic/pull/3373.patch")
+sha256sums=('6b63d857399ba08190c331b545d24e8e3e308b840ff051bbf39e87879e37af50'
+            '60e40900a03308f52dfdb160e36066b53b9af8b5ee1174810d21148bc44ff31f')
 
 _pkgname=gazebo-classic
+
+prepare() {
+    cd "${srcdir}/${_pkgname}-${pkgname}11_$pkgver"
+    patch -Np1 -i ../graphviz-10.patch
+}
 
 build() {
   cd "${srcdir}/${_pkgname}-${pkgname}11_$pkgver"


### PR DESCRIPTION
Fixes #94 by using gazebosim/gazebo-classic#3373
Build and Package logs
[ignition-transport-13.0.0-1-x86_64-build.log](https://github.com/acxz/gazebo-arch/files/14494440/ignition-transport-13.0.0-1-x86_64-build.log)
[ignition-transport-13.0.0-1-x86_64-package.log](https://github.com/acxz/gazebo-arch/files/14494442/ignition-transport-13.0.0-1-x86_64-package.log)
