### PR TITLE
Fix ignition-gui build

### DIFF
--- a/ignition-gui/PKGBUILD
+++ b/ignition-gui/PKGBUILD
@@ -38,7 +38,9 @@ build() {
   cmake .. -DCMAKE_BUILD_TYPE="Release" \
            -DCMAKE_INSTALL_PREFIX="/usr" \
            -DCMAKE_INSTALL_LIBDIR="lib" \
-           -DBUILD_TESTING=OFF
+           -DBUILD_TESTING=OFF \
+           -DCMAKE_CXX_FLAGS="-DGZ_RENDERING_HAVE_VULKAN" \
+           -DCMAKE_C_FLAGS="-DGZ_RENDERING_HAVE_VULKAN"
 
   make
 }


### PR DESCRIPTION
I was trying to build this package but I stumbled into compile errors:
```
[ 55%] Building CXX object src/plugins/minimal_scene/CMakeFiles/MinimalScene.dir/MinimalScene.cc.o
/tmp/oos/ignition-gui/src/gz-gui-gz-gui8_8.0.0/src/plugins/minimal_scene/MinimalScene.cc:592:3: Fehler: »gz::rendering::GzVulkanExternalInstance« wurde
  592 |   rendering::GzVulkanExternalInstance &externalInstance)
      |   ^~~~~~~~~
/tmp/oos/ignition-gui/src/gz-gui-gz-gui8_8.0.0/src/plugins/minimal_scene/MinimalScene.cc: In Funktion »void fillQtInstanceExtensionsToOgre(const QVulkan
/tmp/oos/ignition-gui/src/gz-gui-gz-gui8_8.0.0/src/plugins/minimal_scene/MinimalScene.cc:599:24: Fehler: Abfrage des Elementes »instanceExtensions« in »
assentyp »int« ist
  599 |       externalInstance.instanceExtensions.push_back(VkExtensionProperties{});
      |                        ^~~~~~~~~~~~~~~~~~
/tmp/oos/ignition-gui/src/gz-gui-gz-gui8_8.0.0/src/plugins/minimal_scene/MinimalScene.cc:601:26: Fehler: Abfrage des Elementes »instanceExtensions« in »
assentyp »int« ist
  601 |         externalInstance.instanceExtensions.back();
      |                          ^~~~~~~~~~~~~~~~~~
/tmp/oos/ignition-gui/src/gz-gui-gz-gui8_8.0.0/src/plugins/minimal_scene/MinimalScene.cc:613:24: Fehler: Abfrage des Elementes »instanceLayers« in »exte
ntyp »int« ist
  613 |       externalInstance.instanceLayers.push_back(VkLayerProperties{});
      |                        ^~~~~~~~~~~~~~
/tmp/oos/ignition-gui/src/gz-gui-gz-gui8_8.0.0/src/plugins/minimal_scene/MinimalScene.cc:614:55: Fehler: Abfrage des Elementes »instanceLayers« in »exte
ntyp »int« ist
  614 |       VkLayerProperties &layerProp = externalInstance.instanceLayers.back();
      |                                                       ^~~~~~~~~~~~~~
/tmp/oos/ignition-gui/src/gz-gui-gz-gui8_8.0.0/src/plugins/minimal_scene/MinimalScene.cc: Im globalen Gültigkeitsbereich:
/tmp/oos/ignition-gui/src/gz-gui-gz-gui8_8.0.0/src/plugins/minimal_scene/MinimalScene.cc:627:13: Fehler: Variable oder Feld »fillQtDeviceExtensionsToOgr
  627 | static void fillQtDeviceExtensionsToOgre(
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
/tmp/oos/ignition-gui/src/gz-gui-gz-gui8_8.0.0/src/plugins/minimal_scene/MinimalScene.cc:628:14: Fehler: »GzVulkanExternalDevice« ist kein Element von »
  628 |   rendering::GzVulkanExternalDevice &externalDevice)
      |              ^~~~~~~~~~~~~~~~~~~~~~
/tmp/oos/ignition-gui/src/gz-gui-gz-gui8_8.0.0/src/plugins/minimal_scene/MinimalScene.cc:628:38: Fehler: »externalDevice« wurde in diesem Gültigkeitsber
  628 |   rendering::GzVulkanExternalDevice &externalDevice)
      |                                      ^~~~~~~~~~~~~~
/tmp/oos/ignition-gui/src/gz-gui-gz-gui8_8.0.0/src/plugins/minimal_scene/MinimalScene.cc: In Elementfunktion »std::string gz::gui::plugins::GzRenderer::
ThreadRhi&)«:
/tmp/oos/ignition-gui/src/gz-gui-gz-gui8_8.0.0/src/plugins/minimal_scene/MinimalScene.cc:679:16: Fehler: »GzVulkanExternalInstance« ist kein Element von
  679 |     rendering::GzVulkanExternalInstance externalInstance;
      |                ^~~~~~~~~~~~~~~~~~~~~~~~
/tmp/oos/ignition-gui/src/gz-gui-gz-gui8_8.0.0/src/plugins/minimal_scene/MinimalScene.cc:680:16: Fehler: »GzVulkanExternalDevice« ist kein Element von »
  680 |     rendering::GzVulkanExternalDevice externalDevice;
      |                ^~~~~~~~~~~~~~~~~~~~~~
/tmp/oos/ignition-gui/src/gz-gui-gz-gui8_8.0.0/src/plugins/minimal_scene/MinimalScene.cc:692:7: Fehler: »externalInstance« wurde in diesem Gültigkeitsbe
  692 |       externalInstance.instance = inst->vkInstance();
      |       ^~~~~~~~~~~~~~~~
/tmp/oos/ignition-gui/src/gz-gui-gz-gui8_8.0.0/src/plugins/minimal_scene/MinimalScene.cc:694:7: Fehler: »externalDevice« wurde in diesem Gültigkeitsbere
  694 |       externalDevice.physicalDevice =
      |       ^~~~~~~~~~~~~~
/tmp/oos/ignition-gui/src/gz-gui-gz-gui8_8.0.0/src/plugins/minimal_scene/MinimalScene.cc:706:7: Fehler: »fillQtDeviceExtensionsToOgre« wurde in diesem G
 meinten Sie »fillQtInstanceExtensionsToOgre«?
  706 |       fillQtDeviceExtensionsToOgre(externalDevice);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |       fillQtInstanceExtensionsToOgre
/tmp/oos/ignition-gui/src/gz-gui-gz-gui8_8.0.0/src/plugins/minimal_scene/MinimalScene.cc: Im globalen Gültigkeitsbereich:
/tmp/oos/ignition-gui/src/gz-gui-gz-gui8_8.0.0/src/plugins/minimal_scene/MinimalScene.cc:590:13: Warnung: »void fillQtInstanceExtensionsToOgre(const QVu
er nicht verwendet [-Wunused-function]
  590 | static void fillQtInstanceExtensionsToOgre(
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [src/plugins/minimal_scene/CMakeFiles/MinimalScene.dir/build.make:89: src/plugins/minimal_scene/CMakeFiles/MinimalScene.dir/MinimalScene.cc
make[1]: *** [CMakeFiles/Makefile2:1219: src/plugins/minimal_scene/CMakeFiles/MinimalScene.dir/all] Fehler 2
make: *** [Makefile:146: all] Fehler 2
```
After some debugging, I concluded that setting this flag solves the issue.