### PR TITLE
fixes xmlschema incompatability with recent ruby versions

### DIFF
--- a/sdformat-9/PKGBUILD
+++ b/sdformat-9/PKGBUILD
@@ -18,6 +18,9 @@ _dir="sdformat-sdformat9_${pkgver}"
 
 build() {
   cd "${srcdir}/${_dir}"
+
+  sed -i 's/exists/exist/g' tools/xmlschema.rb
+
   mkdir -p build && cd build
 
   cmake .. -DCMAKE_BUILD_TYPE="Release" \


### PR DESCRIPTION
File.exists has been removed from recent versions of Ruby causing sdformat-9 to no longer compile. This is a text replacement which updates the name of that function.